### PR TITLE
Handle ph=0 in scrollTo

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1720,7 +1720,11 @@ if (typeof Slick === "undefined") {
 
       var oldOffset = offset;
 
-      page = Math.min(n - 1, Math.floor(y / ph));
+      if (ph !== 0) {
+        page = Math.min(n - 1, Math.floor(y / ph));
+      } else {
+        page = 0;
+      }
       offset = Math.round(page * cj);
       var newScrollTop = y - offset;
 


### PR DESCRIPTION
https://github.com/Microsoft/sqlopsstudio/issues/269 happens because `ph` is 0 for some grids that are not visible when `scrollTo` is called the first time. This results in a cascade of `NaN` errors because of division by 0.