### PR TITLE
Added fix for select all and exports

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3820,8 +3820,13 @@ if (typeof Slick === "undefined") {
     function rowsToRanges(rows) {
       var ranges = [];
       var lastCell = columns.length - 1;
-      for (var i = 0; i < rows.length; i++) {
-        ranges.push(new Slick.Range(rows[i], 0, rows[i], lastCell));
+      if (rows.length === renderedRows) {
+        // that means it's select all
+        ranges.push(new Slick.Range(rows[0], 0, rows[rows.length-1], lastCell));
+      } else {
+        for (var i = 0; i < rows.length; i++) {
+          ranges.push(new Slick.Range(rows[i], 0, rows[i], lastCell));
+        }
       }
       return ranges;
     }


### PR DESCRIPTION
Added fixes for all combinations of Selection and Save as Results. Tested the following scenarios -
- [x] Ctrl + A -> right click -> Save as
- [x] Ctrl + A -> Save as button
- [x] Right click -> Select All -> right click -> Save as
- [x] Right click -> Select All -> Save as button
- [x] Mouse drag selection -> Right Click -> Save as
- [x] No selection -> Save as button

Accompanying PR in sqlops here - https://github.com/Microsoft/sqlopsstudio/pull/2521

Fixes -
https://github.com/Microsoft/sqlopsstudio/issues/2372
https://github.com/Microsoft/sqlopsstudio/issues/931
https://github.com/Microsoft/sqlopsstudio/issues/2482