### PR TITLE
Added reset of overflow-x in setoptions

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1512,6 +1512,7 @@ if (typeof Slick === "undefined") {
       validateAndEnforceOptions();
 
       $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
+      $viewport.css("overflow-x", options.forceFitColumns ? "hidden" : "auto");
       if (!suppressRender) { render(); }
     }
 


### PR DESCRIPTION
The horizontal scroll bar state is only set during initial creation of the grid.  This change adds updating the overflow-x update to setOptions() so that it will add/hide the horiz scrollbar based on the current setting of forceFitColumns.